### PR TITLE
Corrige l'encodage source des données Open Data Saône-et-Loire

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -184,6 +184,16 @@
         "qs": "6.7.0",
         "raw-body": "2.4.0",
         "type-is": "~1.6.17"
+      },
+      "dependencies": {
+        "iconv-lite": {
+          "version": "0.4.24",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+          "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3"
+          }
+        }
       }
     },
     "brace-expansion": {
@@ -1032,6 +1042,17 @@
         "chardet": "^0.7.0",
         "iconv-lite": "^0.4.24",
         "tmp": "^0.0.33"
+      },
+      "dependencies": {
+        "iconv-lite": {
+          "version": "0.4.24",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+          "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+          "dev": true,
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3"
+          }
+        }
       }
     },
     "extsprintf": {
@@ -1316,9 +1337,9 @@
       }
     },
     "iconv-lite": {
-      "version": "0.4.24",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.5.0.tgz",
+      "integrity": "sha512-NnEhI9hIEKHOzJ4f697DMz9IQEXr/MMJ5w64vN2/4Ai+wRnvV7SBrL0KLoRlwaKVghOc7LQ5YkPLuX146b6Ydw==",
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
       }
@@ -2045,6 +2066,16 @@
         "http-errors": "1.7.2",
         "iconv-lite": "0.4.24",
         "unpipe": "1.0.0"
+      },
+      "dependencies": {
+        "iconv-lite": {
+          "version": "0.4.24",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+          "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3"
+          }
+        }
       }
     },
     "read-pkg": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "csv-parser": "^2.2.0",
     "decompress": "^4.2.0",
     "express": "^4.16.2",
+    "iconv-lite": "^0.5.0",
     "js-yaml": "^3.8.4",
     "mkdirp": "^0.5.1",
     "mocha": "^4.0.1",

--- a/scripts/saone-et-loire.js
+++ b/scripts/saone-et-loire.js
@@ -1,5 +1,6 @@
 const rp = require('request-promise')
 const csv = require('csv-parser')
+const iconv = require('iconv-lite')
 const utils = require('./utils')
 const Readable = require('stream').Readable
 const types = ['mds', 'maison_handicapees']
@@ -52,18 +53,12 @@ function importOrganismes () {
   return rp({
     uri: 'https://static.data.gouv.fr/resources/implantations-territoriales-de-laction-sociale/20190130-142932/implantations-territoriales-cd71.csv',
     method: 'GET',
-    encoding: 'utf8'
+    encoding: null
   })
     .then(data => {
       return new Promise((resolve, reject) => {
-        // Remove BOM
-        data = data.slice(2)
-
-        // Remove unicode spaces
-        data = data.replace(/\u0000/g, '') // eslint-disable-line
-
         const stream = new Readable()
-        stream.push(data)
+        stream.push(iconv.decode(data, 'utf-16le'))
         stream.push(null)
 
         const results = []


### PR DESCRIPTION
Utilise `iconv-lite` pour décoder le fichier UTF-16 LE.