### PR TITLE
Évite le passage à Node 18

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "repository": "git@github.com:betagouv/annuaire-api.git",
   "engines": {
-    "node": ">= 12"
+    "node": ">= 12 < 18"
   },
   "dependencies": {
     "cors": "^2.8.5",


### PR DESCRIPTION
Le build a échoué sur Scalingo avec cette version